### PR TITLE
Fix compiler warning

### DIFF
--- a/Source/include/ft900_spi.h
+++ b/Source/include/ft900_spi.h
@@ -145,6 +145,12 @@ typedef enum
  */
 int8_t spi_init(ft900_spi_regs_t* dev, spi_dir_t dir, spi_clock_mode_t clock_mode, uint16_t div);
 
+/** @brief Enable the SPI device
+ *  @param dev the device to use
+ *  @returns 0 on a success or -1 for a failure
+ */
+int8_t spi_enable(ft900_spi_regs_t* dev);
+
 /** @brief Disable the SPI device
  *  @param dev the device to use
  *  @returns 0 on a success or -1 for a failure

--- a/Source/src/ethernet.c
+++ b/Source/src/ethernet.c
@@ -538,7 +538,7 @@ int ethernet_read(size_t *blen, uint8_t *buf)
         return 0;
     }
 
-    dst = (uint32_t*)buf;
+    dst = __builtin_assume_aligned(buf, sizeof(uint32_t));
 
     /* Store the current interrupt mask and then disable all interrupts.
      * Note: This is safe to call from within an ISR.
@@ -632,7 +632,7 @@ int ethernet_write(uint8_t *buf, size_t blen)
     size += 3;
     size &= (~3L);
 
-    src = (uint32_t*)buf;
+    src = __builtin_assume_aligned(buf, sizeof(uint32_t));
     data_reg = &ETH->ETH_DATA;
 
     CRITICAL_SECTION_BEGIN

--- a/Source/src/i2cm.c
+++ b/Source/src/i2cm.c
@@ -81,7 +81,7 @@ uint8_t isHighSpeed;		/**< Variable to indicate if high speed mode is enabled */
 
 /* LOCAL FUNCTIONS / INLINES *******************************************************/
 
-static uint8_t i2c_wait_for()
+static uint8_t i2c_wait_for(void)
 {
 	// Noops added because i2cm driver was failing on -02 optimization (works with -O0)
   // It takes some time for the BUSY bit to be set. The NOOPs delay the wait-till-not-busy check 
@@ -108,7 +108,7 @@ void i2cm_init(I2CM_speed_mode mode, uint32_t i2c_clk_speed)
 
 	isHighSpeed = 0;	/* high speed mode is not enabled by default */
 
-	/* Set I2CM clock frequency by writing to I2CM_TIMER_PERIOD – Timer Period Register (address offset: 0x03).
+	/* Set I2CM clock frequency by writing to I2CM_TIMER_PERIOD ï¿½ Timer Period Register (address offset: 0x03).
 	 * Frequency scaler (TIMER_PRD)is used in Standard/Fast/Fast-plus modes to calculate the I2C clock period (SCL_PRD).
 	 *
 	 * In Standard speed mode:

--- a/Source/src/memctl.c
+++ b/Source/src/memctl.c
@@ -50,6 +50,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <ft900.h>
+
 /* CONSTANTS ***********************************************************************/
 
 /**
@@ -405,8 +407,10 @@ void __attribute__((optimize("O0"))) memcpy_pm2dat( void *dest, const __flash__ 
     endLen = newLen & 0x03;
 
     // Pick the initial long destination word to copy to
-    pLongDest = (uint32_t*) ( pDest + destCnt );
+    pLongDest = (uint32_t*) __builtin_assume_aligned(( pDest + destCnt ), sizeof(uint32_t));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
     // Pick the initial source word to start our algorithm at
     if ( srcCnt <= destCnt )
     {
@@ -418,6 +422,7 @@ void __attribute__((optimize("O0"))) memcpy_pm2dat( void *dest, const __flash__ 
         // Set pSrc to the start of the first full word
         pLongSrc = (__flash__ uint32_t*) ( pSrc + srcCnt - 4 );
     }
+#pragma GCC diagnostic pop
 
     // There are 4 different longWord copy methods
     methodSelect = ( srcCnt - destCnt ) & 0x03;
@@ -551,7 +556,7 @@ void memcpy_dat2flash_reboot(uint32_t dst, void *src, size_t s)
  *
  */
 
-void memcpy_pm2flash(uint32_t dst, void *src, size_t s)
+void memcpy_pm2flash(uint32_t dst, const void *src, size_t s)
 {
 	if(s == 0) return; /* Invalid */
 

--- a/Source/src/sdhost.c
+++ b/Source/src/sdhost.c
@@ -2334,7 +2334,7 @@ SDHOST_STATUS sdhost_abort(void) {
 #define CHECK_FUNCTION_HS_MODE      (uint32_t)(0x00FFFFF1)
 
 
-SDHOST_STATUS sdhost_send_wide_data_cmd(uint8_t cmd_id, uint32_t arg, uint8_t* pData, uint16_t blk_size)
+static SDHOST_STATUS sdhost_send_wide_data_cmd(uint8_t cmd_id, uint32_t arg, uint8_t* pData, uint16_t blk_size)
 {
     uint16_t cmd;
     uint16_t transfer_mode;
@@ -2451,7 +2451,7 @@ SDHOST_STATUS sdhost_send_wide_data_cmd(uint8_t cmd_id, uint32_t arg, uint8_t* p
 
 }
 
-bool sdhost_cmd6(void)
+static bool sdhost_cmd6(void)
 {
 
     uint16_t timeout;

--- a/Source/src/usbd.c
+++ b/Source/src/usbd.c
@@ -379,6 +379,12 @@ static const uint8_t USBD_test_pattern_bytes[53] =
 #endif // USBD_ENDPOINT_CHECKS
 
 /* LOCAL FUNCTIONS / INLINES *******************************************************/
+__attribute__((weak)) void USBD_pipe_isr_start(void);
+__attribute__((weak)) void USBD_pipe_isr_stop(void);
+__attribute__((weak)) void USBD_pipe_isr(uint16_t pipe_bitfields);
+__attribute__((weak)) int8_t USBD_standard_req_get_descriptor(
+		USB_device_request *req);
+
 static int32_t usbd_out_request(uint8_t ep_number,
 		uint8_t *buffer, size_t length);
 static int32_t usbd_in_request(uint8_t ep_number,
@@ -612,7 +618,7 @@ static inline void epif_process(void)
 	USBD_pipe_isr_stop();
 }
 
-void ISR_usbd(void)
+static void ISR_usbd(void)
 {
 	cmif_process();
 	epif_process();
@@ -984,7 +990,7 @@ static int8_t usbd_standard_req(USB_device_request *req)
 	return status;
 }
 
-/*static*/ int8_t usbd_check_ep(USBD_ENDPOINT_NUMBER ep_number)
+static int8_t usbd_check_ep(USBD_ENDPOINT_NUMBER ep_number)
 {
 
 	if (ep_number >= USBD_MAX_ENDPOINT_COUNT)
@@ -1455,7 +1461,7 @@ static bool usbd_wait_epx_in_ready(USBD_ENDPOINT_NUMBER   ep_number)
 		if (!USBD_transfer_timeout)
 		{
 			/** clear an in-process transaction */
-			/* Writing a ‘1’ to this bit flushes the next packet to be transmitted from the Endpoint 1 IN FIFO.
+			/* Writing a ï¿½1ï¿½ to this bit flushes the next packet to be transmitted from the Endpoint 1 IN FIFO.
 			 * The FIFO pointer is reset and the INPRDY bit is cleared.
 			 **/
 			USBD_EP_SR_REG(ep_number) = (MASK_USBD_EPxSR_FIFO_FLUSH);

--- a/Source/src/usbd_hbw.c
+++ b/Source/src/usbd_hbw.c
@@ -99,12 +99,14 @@ int32_t usbd_in_request(uint8_t ep_number, const uint8_t *buffer, size_t length)
 
 /* API FUNCTIONS ************************************************************/
 
+#ifdef USBD_HBW_ISOCHRONOUS_AUTOHEADER
 void USBD_HBW_send_end_of_frame(void)
 {
 	//Preserve endpoint number hooked and
 	//Set SEQDATA_END bit
     USBD_HBW->ctrl3 = ((USBD_HBW->ctrl3) & MASK_USBD_HBW_CTRL3_ENDP_NUM) | MASK_USBD_HBW_CTRL3_SEQDATA_END;
 }
+#endif
 
 int8_t USBD_HBW_is_space_avail(void)
 {

--- a/Source/src/usbd_startup_dfu.c
+++ b/Source/src/usbd_startup_dfu.c
@@ -58,6 +58,7 @@
 #include <ft900_usb_dfu.h>
 #include <ft900_usbd.h>
 #include <ft900_usbd_dfu.h>
+#include <ft900_startup_dfu.h>
 
 //#define STARTUP_UART_OUTPUT
 #ifdef STARTUP_UART_OUTPUT

--- a/Source/src/usbh.c
+++ b/Source/src/usbh.c
@@ -391,7 +391,7 @@ static inline uint32_t usbh_read_periodic_list(uint32_t offset)
 
 /** @brief Interrupt handler for USB Host stack.
  */
-void ISR_usbh(void)
+static void ISR_usbh(void)
 {
 #ifdef USBH_USE_INTERRUPTS
 	uint32_t intStatus;
@@ -950,7 +950,7 @@ static void usbh_update_transactions(USBH_xfer **list)
  * endpoints to the next smaller power of 2. e.g. 10 mS will actually poll at
  * 8 mS.
  */
-static void usbh_periodic_init()
+static void usbh_periodic_init(void)
 {
 	uint32_t i;
 	uint32_t reg;
@@ -1031,7 +1031,7 @@ static void usbh_periodic_init()
 
 /** @brief Asynchronous List initialisation.
  */
-static void usbh_asynch_init()
+static void usbh_asynch_init(void)
 {
 	usbh_async_ep_list = usbh_alloc_endpoint();
 	usbh_async_ep_list->enumValue = -1;
@@ -3206,7 +3206,7 @@ static int8_t usbh_hub_port_remove(USBH_device *hubDev, uint8_t hubPort)
 	return status;
 }
 
-static void usbh_update_periodic_tree()
+static void usbh_update_periodic_tree(void)
 {
 	// Device address
 	uint32_t i;
@@ -4534,7 +4534,7 @@ static void usbh_free_hc_buffer(void *hc_buf, uint32_t size)
 }
 
 // Clear 8KB HC shared memory
-static void usbh_hc_memclear()
+static void usbh_hc_memclear(void)
 {
 	uint32_t i;
 

--- a/Source/src/usbh_cdcacm.c
+++ b/Source/src/usbh_cdcacm.c
@@ -605,6 +605,9 @@ int8_t USBH_CDCACM_set_control_line_state(USBH_CDCACM_context *ctx, USB_CDC_cont
 {
     int32_t status;
     USB_device_request devReq;
+	// Control line state is a 16 bit value sent in wValue.
+	uint16_t cpState;
+	memcpy(&cpState, state, sizeof(uint16_t));
 
     if (ctx->acmCapabilities & USB_CDC_ACM_CAPABILITIES_LINE_STATE_CODING)
     {
@@ -612,8 +615,8 @@ int8_t USBH_CDCACM_set_control_line_state(USBH_CDCACM_context *ctx, USB_CDC_cont
 		devReq.bmRequestType = USB_BMREQUESTTYPE_DIR_HOST_TO_DEV |
 				USB_BMREQUESTTYPE_CLASS | USB_BMREQUESTTYPE_RECIPIENT_INTERFACE;
 		devReq.wIndex = ctx->controlInterfaceNumber;
-		devReq.wValue = *((uint16_t *)state);
-		devReq.wLength = sizeof(USB_CDC_control_line_state);
+		devReq.wValue = cpState;
+		devReq.wLength = 0;
 
 		status = USBH_device_setup_transfer(ctx->hControlDevice, &devReq, NULL, 500);
 

--- a/Source/src/usbhx.c
+++ b/Source/src/usbhx.c
@@ -55,6 +55,7 @@
 
 #include <ft900_usb.h>
 #include <ft900_usbh.h>
+#include <ft900_usbhx.h>
 
 /* CONSTANTS ***********************************************************************/
 
@@ -223,7 +224,7 @@ int8_t USBHX_find_by_class(USBH_device_handle *phDev, USBH_interface_handle *phI
     return status;
 }
 
-USBH_STATE USBHX_root_enumerate_wait(void)
+USBH_STATE USBHX_enumerate_wait(void)
 {
     USBH_STATE connect;
 
@@ -292,37 +293,37 @@ static int8_t usbhx_enumerate_parse_config_desc_64(USBH_device_handle hDev, uint
 	return usbhx_enumerate_parse_config_desc(hDev, type, index, offset, len, buf, buf0);
 }
 
-int8_t usbhx_enumerate_parse_config_desc_128(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
+static int8_t usbhx_enumerate_parse_config_desc_128(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
 {
 	uint8_t buf0[128];
 	return usbhx_enumerate_parse_config_desc(hDev, type, index, offset, len, buf, buf0);
 }
 
-int8_t usbhx_enumerate_parse_config_desc_256(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
+static int8_t usbhx_enumerate_parse_config_desc_256(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
 {
 	uint8_t buf0[256];
 	return usbhx_enumerate_parse_config_desc(hDev, type, index, offset, len, buf, buf0);
 }
 
-int8_t usbhx_enumerate_parse_config_desc_512(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
+static int8_t usbhx_enumerate_parse_config_desc_512(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
 {
 	uint8_t buf0[512];
 	return usbhx_enumerate_parse_config_desc(hDev, type, index, offset, len, buf, buf0);
 }
 
-int8_t usbhx_enumerate_parse_config_desc_1024(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
+static int8_t usbhx_enumerate_parse_config_desc_1024(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
 {
 	uint8_t buf0[1024];
 	return usbhx_enumerate_parse_config_desc(hDev, type, index, offset, len, buf, buf0);
 }
 
-int8_t usbhx_enumerate_parse_config_desc_2048(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
+static int8_t usbhx_enumerate_parse_config_desc_2048(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
 {
 	uint8_t buf0[2048];
 	return usbhx_enumerate_parse_config_desc(hDev, type, index, offset, len, buf, buf0);
 }
 
-int8_t usbhx_enumerate_parse_config_desc_4096(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
+static int8_t usbhx_enumerate_parse_config_desc_4096(USBH_device_handle hDev, uint8_t type, uint8_t index, uint16_t offset, uint16_t len, uint8_t *buf)
 {
 	uint8_t buf0[4096];
 	return usbhx_enumerate_parse_config_desc(hDev, type, index, offset, len, buf, buf0);


### PR DESCRIPTION
* Fixes for pedantic compiler options in header and source files, e.g. cast-align, strict-prototypes and pedantic.
* Adding missing required header file includes to usbd_startup_dfu.c, usbhx.c.
* Use of gcc builtin macros in ethernet.c, i2cm.c, memctrl.c, usbd_rndis.c, usbh_cdcacm.c, to prevent cast-align warnings.