### PR TITLE
30 interrupt endpoints on low speed devices over hubs

### DIFF
--- a/Source/src/usbh.c
+++ b/Source/src/usbh.c
@@ -464,11 +464,11 @@ static void usbh_unlink_qtd(USBH_xfer *xferThis)
 	token = EHCI_MEM(hc_this_qtd->token);
 	if (token & EHCI_QUEUE_TD_TOKEN_STATUS_ACTIVE)
 			{
-		USBH_qtd *hc_next_qtd = EHCI_MEM(hc_this_qh->transfer_overlay.next);
+		USBH_qtd *hc_next_qtd = (USBH_qtd *)EHCI_MEM(hc_this_qh->transfer_overlay.next);
 		EHCI_MEM(hc_this_qtd->token) = token & (~EHCI_QUEUE_TD_TOKEN_STATUS_ACTIVE);
 		EHCI_MEM(hc_this_qh->transfer_overlay.next) = EHCI_MEM(hc_this_qh->qtd_current);
 		EHCI_MEM(hc_this_qh->transfer_overlay.alt_next) = EHCI_MEM(hc_this_qh->qtd_current);
-		EHCI_MEM(hc_this_qh->qtd_current) = hc_next_qtd;
+		EHCI_MEM(hc_this_qh->qtd_current) = (uint32_t)hc_next_qtd;
 			}
 
 	// Restart the schedule.
@@ -4360,7 +4360,7 @@ static void usbh_force_close_xfer(USBH_endpoint *ep, USBH_xfer *list)
 			{
 				// Deactivate qTD
 				usbh_unlink_qtd(xferThis);
-				//xferThis->token = token & MASK_EHCI_QUEUE_TD_TOKEN_STATUS;
+
 				xferThis->status = USBH_ERR_REMOVED;
 			}
 		}

--- a/Source/src/usbh.c
+++ b/Source/src/usbh.c
@@ -1332,24 +1332,22 @@ static int8_t usbh_ep_list_remove(USBH_endpoint *epThis, USBH_endpoint *epListHe
 static USBH_endpoint *usbh_ep_list_find_periodic(uint16_t interval)
 {
 	USBH_endpoint *end_ep = usbh_periodic_ep_list;
-	USBH_endpoint *found_ep = NULL;
 
 	// Move through the endpoint list and find where the first endpoint with the
 	// required interval (or less) is found.
 	while (end_ep)
 	{
-		if ((end_ep->interval != 65535) && (end_ep->interval <= ((interval * 2) - 1)))
+		if (end_ep->interval <= ((interval * 2) - 1))
 		{
 			// Insert before end_ep in the list
 			// If this is the first pass then add to end of list (after dummy entry).
-			found_ep = end_ep;
 			break;
 		}
 
 		end_ep = end_ep->list_next;
 	}
 
-	return found_ep;
+	return end_ep;
 }
 
 static int8_t usbh_init_ep_qh(USBH_list_entry *hc_this_entry, USBH_qh *hc_ctrl_qh, USBH_endpoint *this_ep)


### PR DESCRIPTION
To test #30 and improve #25.
Implement better SSPLIT/CSPLIT masks for low-speed devices over bridges. Correctly stop the periodic or async list when removing timed-out transfers.
