### PR TITLE
Increase TDRST on downward facing hub port #30

### DIFF
--- a/Source/src/usbh.c
+++ b/Source/src/usbh.c
@@ -3927,7 +3927,7 @@ static int8_t usbh_hub_port_enumerate(USBH_device *hubDev, uint8_t hubPort, uint
 	else
 	{
 		// TDRST Min 10 ms, Max 20 ms delay
-		delayms(10);
+		delayms(20);
 	}
 
 	status += usbh_clear_hub_port_feature(hubDev, hubPort, USB_HUB_CLASS_FEATURE_PORT_RESET);


### PR DESCRIPTION
This increase adds 10 ms to the time that enumeration waits for a reset driven on a downstream hub port. Previously the delay was for 10 ms, however Table 7-13 has 10 ms as the minimum time and 20 ms as the maximum time. Since this is controlled by the hub the hub may drive it for 20 ms. See "11.5.1.5 Resetting".